### PR TITLE
Introduce public profiles and public posts

### DIFF
--- a/cmd/web/actions.go
+++ b/cmd/web/actions.go
@@ -366,7 +366,7 @@ func setupActions(r *gin.RouterGroup, db *sqlx.DB, mediaServer media.MediaServer
 			return
 		}
 
-		capabilities := postops.GetPostCapabilities(userData.DBUser.ID, post.UserID, connectionRadius)
+		capabilities := postops.GetPostCapabilities(connectionRadius)
 
 		if !capabilities.CanShare {
 			reportError(c, "Operation not allowed")
@@ -431,7 +431,7 @@ func setupActions(r *gin.RouterGroup, db *sqlx.DB, mediaServer media.MediaServer
 			return
 		}
 
-		capabilities := postops.GetPostCapabilities(userData.DBUser.ID, post.UserID, connectionRadius)
+		capabilities := postops.GetPostCapabilities(connectionRadius)
 
 		if !capabilities.CanShare {
 			reportError(c, "Operation not allowed")

--- a/cmd/web/client/html/form--post.html
+++ b/cmd/web/client/html/form--post.html
@@ -97,6 +97,15 @@
           Show to their connections as well
         </label>
       </div>
+      <div class="form-check">
+        <input class="form-check-input" type="radio" name="visibility" id="visibilityPublic"
+                                                                      value="public"
+        {{ if .Input }}{{ if eq .Input.Visibility "public" }}checked{{ end }}{{ end }}
+        >
+        <label class="form-check-label" for="visibilityPublic">
+          Public
+        </label>
+      </div>
       {{ if (.Errors.HasError "visibility") }}
       <div class="invalid-feedback">{{ .Errors.visibility }}</div>
       {{ end }}

--- a/cmd/web/client/html/form--settings-general.html
+++ b/cmd/web/client/html/form--settings-general.html
@@ -37,5 +37,24 @@
     {{ end }}
   </div>
 
+  <div class="mb-3">
+    <label for="settingsTimeZone" class="form-label">Profile Visibility</label>
+    <select name="profile_visibility"
+            class="form-control {{ if (.Errors.HasError "profile_visibility") }}is-invalid{{ end }}"
+            >
+        {{ $selected := .User.ProfileVisibility }}
+        {{ if (and .Input .Input.ProfileVisibility) }}
+          {{ $selected_tz = .Input.ProfileVisibility }}
+        {{ end }}
+
+        {{ range .ProfileVisibility }}
+          <option value="{{ .Value }}" {{ if eq .Value $selected_tz }}selected{{ end }}>{{ .Label }}</option>
+        {{ end }}
+    </select>
+    {{ if (.Errors.HasError "profile_visibility") }}
+    <div class="invalid-feedback">{{ .Errors.profile_visibility }}</div>
+    {{ end }}
+  </div>
+
   <button type="submit" class="btn btn-primary">Save Settings</button>
 </form>

--- a/cmd/web/client/html/settings.html
+++ b/cmd/web/client/html/settings.html
@@ -1,16 +1,15 @@
 {{ template "header.html" . }}
 
-{{ $user := .User.DBUser }}
 <div class="container mt-lg-4 mt-2">
   <h1>Settings</h1>
 
-  <div class="row">
+  <div class="rmw">
     <div class="col-lg-6 mt-2">
 
       <div class="card">
         <h5 class="card-header">General</h5>
         <div class="card-body">
-          {{ template "form--settings-general.html" toMap "User" $user }}
+          {{ template "form--settings-general.html" .GeneralSettings.TemplateData }}
         </div>
       </div>
 

--- a/cmd/web/client/html/user_home.html
+++ b/cmd/web/client/html/user_home.html
@@ -4,6 +4,7 @@
   <div class="row justify-content-md-center mt-lg-4 mt-2">
     <h1><a href="{{ link "user" .Author.Username }}">{{ .Author.Username }}</a>  &#8594; Latest Posts</h1>
 
+    {{ if .User.IsLoggedIn }}
     <div class="alert alert-info mt-2" role="alert">
       {{ if .ConnectionRadius.IsSameUser }}You're reading your own journal
       {{- else if .ConnectionRadius.IsDirect }}
@@ -54,6 +55,7 @@
         {{ end }}
       {{- else if .ConnectionRadius.IsUnrelated }}You have no relation to {{ .Author.Username }}{{ end }}
     </div>
+    {{ end }}
 
     {{ if .ConnectionRadius.IsUnrelated }}
     <p>You are not allowed to see posts in this journal</p>

--- a/cmd/web/main.go
+++ b/cmd/web/main.go
@@ -339,7 +339,7 @@ func main() {
 		})
 	})
 
-	r.GET("/users/:username", auth.EnforceAuth, func(c *gin.Context) {
+	r.GET("/users/:username", func(c *gin.Context) {
 		userData := auth.GetUserData(c)
 		username := c.Param("username")
 

--- a/cmd/web/main.go
+++ b/cmd/web/main.go
@@ -353,7 +353,7 @@ func main() {
 		ginhelpers.HTML(c, "shared_post.html", web.SharedPost(c, db, &userData, shareID))
 	})
 
-	r.GET("/posts/:id", auth.EnforceAuth, func(c *gin.Context) {
+	r.GET("/posts/:id", func(c *gin.Context) {
 		userData := auth.GetUserData(c)
 		postID := c.Param("id")
 		editPreview := c.Query("edit_preview") == "true"
@@ -361,7 +361,7 @@ func main() {
 		ginhelpers.HTML(c, "single_post.html", web.SinglePost(c, db, &userData, postID, editPreview))
 	})
 
-	r.GET("/posts/:id/md", auth.EnforceAuth, func(c *gin.Context) {
+	r.GET("/posts/:id/md", func(c *gin.Context) {
 		userData := auth.GetUserData(c)
 		postID := c.Param("id")
 
@@ -381,7 +381,7 @@ func main() {
 		c.String(http.StatusOK, string(serialized))
 	})
 
-	r.GET("/posts/:id/zip", auth.EnforceAuth, func(c *gin.Context) {
+	r.GET("/posts/:id/zip", func(c *gin.Context) {
 		userData := auth.GetUserData(c)
 		user := userData.DBUser
 		postID := c.Param("id")

--- a/migrations/20241129105325-profile_visibility.sql
+++ b/migrations/20241129105325-profile_visibility.sql
@@ -1,0 +1,8 @@
+
+-- +migrate Up
+create type profile_visibility as ENUM ('connections', 'registered_users', 'public');
+alter table users add column profile_visibility profile_visibility not null default 'registered_users';
+
+-- +migrate Down
+alter table users drop column profile_visibility;
+drop type profile_visibility;

--- a/migrations/20241129115605-post_visibility_public.sql
+++ b/migrations/20241129115605-post_visibility_public.sql
@@ -1,0 +1,5 @@
+
+-- +migrate Up
+alter type post_visibility add value 'public';
+
+-- +migrate Down

--- a/pkg/forms/form_comment_new.go
+++ b/pkg/forms/form_comment_new.go
@@ -73,7 +73,7 @@ func (f *NewCommentForm) Validate(c *gin.Context, db boil.ContextExecutor) error
 		return err
 	}
 
-	capabilities := postops.GetPostCapabilities(f.User.ID, post.UserID, connRadius)
+	capabilities := postops.GetPostCapabilities(connRadius)
 
 	if !capabilities.CanLeaveComments {
 		return ginhelpers.ErrForbidden

--- a/pkg/forms/form_post_new.go
+++ b/pkg/forms/form_post_new.go
@@ -154,8 +154,8 @@ func (f *PostForm) Validate(c *gin.Context, db boil.ContextExecutor) error {
 	}
 
 	if err := validation.ValidateEnum(f.Input.Visibility,
-		[]core.PostVisibility{core.PostVisibilityDirectOnly, core.PostVisibilitySecondDegree},
-		[]string{"direct only", "their connections as well"}); err != nil {
+		[]core.PostVisibility{core.PostVisibilityDirectOnly, core.PostVisibilitySecondDegree, core.PostVisibilityPublic},
+		[]string{"direct only", "their connections as well", "public"}); err != nil {
 		f.AddError("visibility", err.Error())
 	}
 
@@ -171,7 +171,7 @@ func (f *PostForm) Validate(c *gin.Context, db boil.ContextExecutor) error {
 			return err
 		}
 
-		capabilities := postops.GetPostCapabilities(f.User.ID, post.UserID, radius)
+		capabilities := postops.GetPostCapabilities(radius)
 
 		if !capabilities.CanEdit {
 			return ginhelpers.ErrForbidden
@@ -205,7 +205,7 @@ func (f *PostForm) Save(c context.Context, exec boil.ContextExecutor) (forms.For
 		Subject:          subject,
 		Body:             body,
 		UserID:           f.User.ID,
-		VisibilityRadius: core.PostVisibility(f.Input.Visibility),
+		VisibilityRadius: f.Input.Visibility,
 	}
 
 	var action = forms.FormSaveDefault(true)

--- a/pkg/forms/form_settings_general.go
+++ b/pkg/forms/form_settings_general.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/can3p/gogo/forms"
+	"github.com/can3p/pcom/pkg/forms/values"
 	"github.com/can3p/pcom/pkg/model/core"
 	"github.com/can3p/pcom/pkg/util"
 	"github.com/gin-gonic/gin"
@@ -13,7 +14,8 @@ import (
 )
 
 type SettingsGeneralFormInput struct {
-	Timezone string `form:"timezone"`
+	Timezone          string `form:"timezone"`
+	ProfileVisibility string `form:"profile_visibility"`
 }
 
 type SettingsGeneralForm struct {
@@ -21,15 +23,16 @@ type SettingsGeneralForm struct {
 	User *core.User
 }
 
-func SettingsGeneralFormNew(u *core.User) forms.Form {
-	var form forms.Form = &SettingsGeneralForm{
+func SettingsGeneralFormNew(u *core.User) *SettingsGeneralForm {
+	form := &SettingsGeneralForm{
 		FormBase: &forms.FormBase[SettingsGeneralFormInput]{
 			Name:                "settings_general",
 			FormTemplate:        "form--settings-general.html",
 			KeepValuesAfterSave: true,
 			Input:               &SettingsGeneralFormInput{},
 			ExtraTemplateData: map[string]interface{}{
-				"User": u,
+				"User":              u,
+				"ProfileVisibility": values.ProfileVisibilityValues,
 			},
 		},
 		User: u,
@@ -41,6 +44,11 @@ func SettingsGeneralFormNew(u *core.User) forms.Form {
 func (f *SettingsGeneralForm) Validate(c *gin.Context, db boil.ContextExecutor) error {
 	if f.Input.Timezone == "" {
 		f.AddError("timezone", "timezone is required")
+		return forms.ErrValidationFailed
+	}
+
+	if f.Input.ProfileVisibility == "" {
+		f.AddError("profile_visibility", "Profile visibility is required")
 		return forms.ErrValidationFailed
 	}
 
@@ -57,14 +65,21 @@ func (f *SettingsGeneralForm) Validate(c *gin.Context, db boil.ContextExecutor) 
 		return forms.ErrValidationFailed
 	}
 
+	if err := core.ProfileVisibility(f.Input.ProfileVisibility).IsValid(); err != nil {
+		f.AddError("profile_visibility", fmt.Sprintf("Invalid value [%s]", f.Input.ProfileVisibility))
+		return forms.ErrValidationFailed
+	}
+
 	return nil
 }
 
 func (f *SettingsGeneralForm) Save(c context.Context, exec boil.ContextExecutor) (forms.FormSaveAction, error) {
 	f.User.Timezone = f.Input.Timezone
+	f.User.ProfileVisibility = core.ProfileVisibility(f.Input.ProfileVisibility)
 
 	if _, err := f.User.Update(c, exec, boil.Whitelist(
 		core.UserColumns.Timezone,
+		core.UserColumns.ProfileVisibility,
 		core.UserColumns.UpdatedAt,
 	)); err != nil {
 		return nil, errors.Wrapf(err, "failed to save to the db")

--- a/pkg/forms/values/values.go
+++ b/pkg/forms/values/values.go
@@ -1,0 +1,16 @@
+package values
+
+import "github.com/can3p/pcom/pkg/model/core"
+
+type SelectValue struct {
+	Label string
+	Value string
+}
+
+type ValueList []SelectValue
+
+var ProfileVisibilityValues = ValueList{
+	{Label: "All registered users", Value: string(core.ProfileVisibilityRegisteredUsers)},
+	{Label: "Direct and indirect connections", Value: string(core.ProfileVisibilityConnections)},
+	{Label: "Public", Value: string(core.ProfileVisibilityPublic)},
+}

--- a/pkg/model/core/boil_types.go
+++ b/pkg/model/core/boil_types.go
@@ -106,18 +106,20 @@ type PostVisibility string
 const (
 	PostVisibilityDirectOnly   PostVisibility = "direct_only"
 	PostVisibilitySecondDegree PostVisibility = "second_degree"
+	PostVisibilityPublic       PostVisibility = "public"
 )
 
 func AllPostVisibility() []PostVisibility {
 	return []PostVisibility{
 		PostVisibilityDirectOnly,
 		PostVisibilitySecondDegree,
+		PostVisibilityPublic,
 	}
 }
 
 func (e PostVisibility) IsValid() error {
 	switch e {
-	case PostVisibilityDirectOnly, PostVisibilitySecondDegree:
+	case PostVisibilityDirectOnly, PostVisibilitySecondDegree, PostVisibilityPublic:
 		return nil
 	default:
 		return errors.New("enum is not valid")
@@ -134,6 +136,8 @@ func (e PostVisibility) Ordinal() int {
 		return 0
 	case PostVisibilitySecondDegree:
 		return 1
+	case PostVisibilityPublic:
+		return 2
 
 	default:
 		panic(errors.New("enum is not valid"))

--- a/pkg/model/core/boil_types.go
+++ b/pkg/model/core/boil_types.go
@@ -327,3 +327,47 @@ func (e ConnectionMediationDecision) Ordinal() int {
 		panic(errors.New("enum is not valid"))
 	}
 }
+
+type ProfileVisibility string
+
+// Enum values for ProfileVisibility
+const (
+	ProfileVisibilityConnections     ProfileVisibility = "connections"
+	ProfileVisibilityRegisteredUsers ProfileVisibility = "registered_users"
+	ProfileVisibilityPublic          ProfileVisibility = "public"
+)
+
+func AllProfileVisibility() []ProfileVisibility {
+	return []ProfileVisibility{
+		ProfileVisibilityConnections,
+		ProfileVisibilityRegisteredUsers,
+		ProfileVisibilityPublic,
+	}
+}
+
+func (e ProfileVisibility) IsValid() error {
+	switch e {
+	case ProfileVisibilityConnections, ProfileVisibilityRegisteredUsers, ProfileVisibilityPublic:
+		return nil
+	default:
+		return errors.New("enum is not valid")
+	}
+}
+
+func (e ProfileVisibility) String() string {
+	return string(e)
+}
+
+func (e ProfileVisibility) Ordinal() int {
+	switch e {
+	case ProfileVisibilityConnections:
+		return 0
+	case ProfileVisibilityRegisteredUsers:
+		return 1
+	case ProfileVisibilityPublic:
+		return 2
+
+	default:
+		panic(errors.New("enum is not valid"))
+	}
+}

--- a/pkg/model/core/users.go
+++ b/pkg/model/core/users.go
@@ -24,16 +24,17 @@ import (
 
 // User is an object representing the database table.
 type User struct {
-	ID                string      `boil:"id" json:"id" toml:"id" yaml:"id"`
-	Email             string      `boil:"email" json:"email" toml:"email" yaml:"email"`
-	CreatedAt         null.Time   `boil:"created_at" json:"created_at,omitempty" toml:"created_at" yaml:"created_at,omitempty"`
-	UpdatedAt         null.Time   `boil:"updated_at" json:"updated_at,omitempty" toml:"updated_at" yaml:"updated_at,omitempty"`
-	Timezone          string      `boil:"timezone" json:"timezone" toml:"timezone" yaml:"timezone"`
-	EmailConfirmedAt  null.Time   `boil:"email_confirmed_at" json:"email_confirmed_at,omitempty" toml:"email_confirmed_at" yaml:"email_confirmed_at,omitempty"`
-	EmailConfirmSeed  null.String `boil:"email_confirm_seed" json:"email_confirm_seed,omitempty" toml:"email_confirm_seed" yaml:"email_confirm_seed,omitempty"`
-	SignupAttribution null.String `boil:"signup_attribution" json:"signup_attribution,omitempty" toml:"signup_attribution" yaml:"signup_attribution,omitempty"`
-	Pwdhash           null.String `boil:"pwdhash" json:"pwdhash,omitempty" toml:"pwdhash" yaml:"pwdhash,omitempty"`
-	Username          string      `boil:"username" json:"username" toml:"username" yaml:"username"`
+	ID                string            `boil:"id" json:"id" toml:"id" yaml:"id"`
+	Email             string            `boil:"email" json:"email" toml:"email" yaml:"email"`
+	CreatedAt         null.Time         `boil:"created_at" json:"created_at,omitempty" toml:"created_at" yaml:"created_at,omitempty"`
+	UpdatedAt         null.Time         `boil:"updated_at" json:"updated_at,omitempty" toml:"updated_at" yaml:"updated_at,omitempty"`
+	Timezone          string            `boil:"timezone" json:"timezone" toml:"timezone" yaml:"timezone"`
+	EmailConfirmedAt  null.Time         `boil:"email_confirmed_at" json:"email_confirmed_at,omitempty" toml:"email_confirmed_at" yaml:"email_confirmed_at,omitempty"`
+	EmailConfirmSeed  null.String       `boil:"email_confirm_seed" json:"email_confirm_seed,omitempty" toml:"email_confirm_seed" yaml:"email_confirm_seed,omitempty"`
+	SignupAttribution null.String       `boil:"signup_attribution" json:"signup_attribution,omitempty" toml:"signup_attribution" yaml:"signup_attribution,omitempty"`
+	Pwdhash           null.String       `boil:"pwdhash" json:"pwdhash,omitempty" toml:"pwdhash" yaml:"pwdhash,omitempty"`
+	Username          string            `boil:"username" json:"username" toml:"username" yaml:"username"`
+	ProfileVisibility ProfileVisibility `boil:"profile_visibility" json:"profile_visibility" toml:"profile_visibility" yaml:"profile_visibility"`
 
 	R *userR `boil:"-" json:"-" toml:"-" yaml:"-"`
 	L userL  `boil:"-" json:"-" toml:"-" yaml:"-"`
@@ -50,6 +51,7 @@ var UserColumns = struct {
 	SignupAttribution string
 	Pwdhash           string
 	Username          string
+	ProfileVisibility string
 }{
 	ID:                "id",
 	Email:             "email",
@@ -61,6 +63,7 @@ var UserColumns = struct {
 	SignupAttribution: "signup_attribution",
 	Pwdhash:           "pwdhash",
 	Username:          "username",
+	ProfileVisibility: "profile_visibility",
 }
 
 var UserTableColumns = struct {
@@ -74,6 +77,7 @@ var UserTableColumns = struct {
 	SignupAttribution string
 	Pwdhash           string
 	Username          string
+	ProfileVisibility string
 }{
 	ID:                "users.id",
 	Email:             "users.email",
@@ -85,9 +89,45 @@ var UserTableColumns = struct {
 	SignupAttribution: "users.signup_attribution",
 	Pwdhash:           "users.pwdhash",
 	Username:          "users.username",
+	ProfileVisibility: "users.profile_visibility",
 }
 
 // Generated where
+
+type whereHelperProfileVisibility struct{ field string }
+
+func (w whereHelperProfileVisibility) EQ(x ProfileVisibility) qm.QueryMod {
+	return qmhelper.Where(w.field, qmhelper.EQ, x)
+}
+func (w whereHelperProfileVisibility) NEQ(x ProfileVisibility) qm.QueryMod {
+	return qmhelper.Where(w.field, qmhelper.NEQ, x)
+}
+func (w whereHelperProfileVisibility) LT(x ProfileVisibility) qm.QueryMod {
+	return qmhelper.Where(w.field, qmhelper.LT, x)
+}
+func (w whereHelperProfileVisibility) LTE(x ProfileVisibility) qm.QueryMod {
+	return qmhelper.Where(w.field, qmhelper.LTE, x)
+}
+func (w whereHelperProfileVisibility) GT(x ProfileVisibility) qm.QueryMod {
+	return qmhelper.Where(w.field, qmhelper.GT, x)
+}
+func (w whereHelperProfileVisibility) GTE(x ProfileVisibility) qm.QueryMod {
+	return qmhelper.Where(w.field, qmhelper.GTE, x)
+}
+func (w whereHelperProfileVisibility) IN(slice []ProfileVisibility) qm.QueryMod {
+	values := make([]interface{}, 0, len(slice))
+	for _, value := range slice {
+		values = append(values, value)
+	}
+	return qm.WhereIn(fmt.Sprintf("%s IN ?", w.field), values...)
+}
+func (w whereHelperProfileVisibility) NIN(slice []ProfileVisibility) qm.QueryMod {
+	values := make([]interface{}, 0, len(slice))
+	for _, value := range slice {
+		values = append(values, value)
+	}
+	return qm.WhereNotIn(fmt.Sprintf("%s NOT IN ?", w.field), values...)
+}
 
 var UserWhere = struct {
 	ID                whereHelperstring
@@ -100,6 +140,7 @@ var UserWhere = struct {
 	SignupAttribution whereHelpernull_String
 	Pwdhash           whereHelpernull_String
 	Username          whereHelperstring
+	ProfileVisibility whereHelperProfileVisibility
 }{
 	ID:                whereHelperstring{field: "\"users\".\"id\""},
 	Email:             whereHelperstring{field: "\"users\".\"email\""},
@@ -111,6 +152,7 @@ var UserWhere = struct {
 	SignupAttribution: whereHelpernull_String{field: "\"users\".\"signup_attribution\""},
 	Pwdhash:           whereHelpernull_String{field: "\"users\".\"pwdhash\""},
 	Username:          whereHelperstring{field: "\"users\".\"username\""},
+	ProfileVisibility: whereHelperProfileVisibility{field: "\"users\".\"profile_visibility\""},
 }
 
 // UserRels is where relationship names are stored.
@@ -291,9 +333,9 @@ func (r *userR) GetWhoWhitelistedConnections() WhitelistedConnectionSlice {
 type userL struct{}
 
 var (
-	userAllColumns            = []string{"id", "email", "created_at", "updated_at", "timezone", "email_confirmed_at", "email_confirm_seed", "signup_attribution", "pwdhash", "username"}
+	userAllColumns            = []string{"id", "email", "created_at", "updated_at", "timezone", "email_confirmed_at", "email_confirm_seed", "signup_attribution", "pwdhash", "username", "profile_visibility"}
 	userColumnsWithoutDefault = []string{"id", "email", "timezone", "username"}
-	userColumnsWithDefault    = []string{"created_at", "updated_at", "email_confirmed_at", "email_confirm_seed", "signup_attribution", "pwdhash"}
+	userColumnsWithDefault    = []string{"created_at", "updated_at", "email_confirmed_at", "email_confirm_seed", "signup_attribution", "pwdhash", "profile_visibility"}
 	userPrimaryKeyColumns     = []string{"id"}
 	userGeneratedColumns      = []string{}
 )

--- a/pkg/postops/postops.go
+++ b/pkg/postops/postops.go
@@ -34,14 +34,14 @@ type PostCapabilities struct {
 	CanShare         bool
 }
 
-func GetPostCapabilities(userID string, authorID string, radius userops.ConnectionRadius) *PostCapabilities {
+func GetPostCapabilities(radius userops.ConnectionRadius) *PostCapabilities {
 	return &PostCapabilities{
 		// it can be different in the future, e.g. if the author disables
 		// new comments at some point
 		CanViewComments:  radius.IsDirect() || radius.IsSameUser(),
 		CanLeaveComments: radius.IsDirect() || radius.IsSameUser(),
-		CanEdit:          userID == authorID,
-		CanShare:         userID == authorID,
+		CanEdit:          radius.IsSameUser(),
+		CanShare:         radius.IsSameUser(),
 	}
 }
 
@@ -75,7 +75,7 @@ func ConstructPost(user *core.User, post *core.Post, radius userops.ConnectionRa
 		Author:         post.R.User,
 		Post:           post,
 		CommentsNumber: commentsNum,
-		Capabilities:   GetPostCapabilities(user.ID, post.R.User.ID, radius),
+		Capabilities:   GetPostCapabilities(radius),
 		EditPreview:    editPreview && radius.IsSameUser(), // only authors can preview their own posts
 		Radius:         radius,
 		Via:            via,

--- a/pkg/postops/postops.go
+++ b/pkg/postops/postops.go
@@ -27,6 +27,21 @@ func (c *Comment) String() string {
 		c.ID, c.ParentCommentID.String, c.CreatedAt.Format(time.ANSIC), c.Author.Username)
 }
 
+func CanSeePost(p *core.Post, radius userops.ConnectionRadius) bool {
+	switch {
+	case radius.IsSameUser():
+		fallthrough
+	case radius.IsDirect():
+		fallthrough
+	case radius.IsSecondDegree() && p.VisibilityRadius == core.PostVisibilitySecondDegree:
+		fallthrough
+	case p.VisibilityRadius == core.PostVisibilityPublic:
+		return true
+	}
+
+	return false
+}
+
 type PostCapabilities struct {
 	CanViewComments  bool
 	CanLeaveComments bool

--- a/pkg/userops/connections.go
+++ b/pkg/userops/connections.go
@@ -17,6 +17,7 @@ import (
 )
 
 var ErrNoConnectionRequest = errors.Errorf("No such connection request")
+var ErrUserNotSignedIn = errors.Errorf("One of the users is not signed in")
 
 // CreateConnection assumes it's run in transaction
 // Since connections form an undirected graph, we insert
@@ -154,6 +155,10 @@ func (cr ConnectionRadius) IsUnrelated() bool {
 }
 
 func GetConnectionRadius(ctx context.Context, db boil.ContextExecutor, fromUserID string, toUserID string) (ConnectionRadius, error) {
+	if fromUserID == "" || toUserID == "" {
+		return ConnectionRadiusUnknown, ErrUserNotSignedIn
+	}
+
 	if fromUserID == toUserID {
 		return ConnectionRadiusSameUser, nil
 	}

--- a/pkg/userops/profile.go
+++ b/pkg/userops/profile.go
@@ -1,0 +1,20 @@
+package userops
+
+import "github.com/can3p/pcom/pkg/model/core"
+
+func CanSeeProfile(profile *core.User, visitor *core.User, connRadius ConnectionRadius) bool {
+	switch {
+	case profile.ProfileVisibility == core.ProfileVisibilityPublic:
+		return true
+	case profile.ProfileVisibility == core.ProfileVisibilityRegisteredUsers && visitor != nil:
+		return true
+	case profile.ProfileVisibility == core.ProfileVisibilityConnections && !(connRadius == ConnectionRadiusUnrelated || connRadius == ConnectionRadiusUnknown):
+		return true
+	}
+
+	return false
+}
+
+func CannotSeeProfileLite(profile *core.User, visitor *core.User) bool {
+	return profile.ProfileVisibility != core.ProfileVisibilityPublic && visitor == nil
+}

--- a/pkg/web/func.go
+++ b/pkg/web/func.go
@@ -232,6 +232,7 @@ type SettingsPage struct {
 	AvailableInvites int64
 	UsedInvites      core.UserInvitationSlice
 	ActiveAPIKey     *core.UserAPIKey
+	GeneralSettings  *forms.SettingsGeneralForm
 }
 
 func Settings(c *gin.Context, db boil.ContextExecutor, userData *auth.UserData) mo.Result[*SettingsPage] {
@@ -265,6 +266,7 @@ func Settings(c *gin.Context, db boil.ContextExecutor, userData *auth.UserData) 
 		AvailableInvites: totalInvites - int64(len(usedInvites)),
 		UsedInvites:      usedInvites,
 		ActiveAPIKey:     apiKey,
+		GeneralSettings:  forms.SettingsGeneralFormNew(userData.DBUser),
 	}
 
 	return mo.Ok(settingsPage)


### PR DESCRIPTION
We've tried to stay private only for a while but it makes sense to add an ability to share posts with wide audience. The main reason is that nobody want to register in yet another random service, hence we need to adapt

Everything is still private first, and anon users cannot comment just now.