### PR TITLE
Implement rss feeds

### DIFF
--- a/cmd/web/api.go
+++ b/cmd/web/api.go
@@ -3,6 +3,7 @@ package main
 import (
 	"github.com/can3p/gogo/sender"
 	"github.com/can3p/pcom/pkg/auth"
+	"github.com/can3p/pcom/pkg/links"
 	"github.com/can3p/pcom/pkg/media"
 	"github.com/can3p/pcom/pkg/util/ginhelpers"
 	"github.com/can3p/pcom/pkg/web"
@@ -20,13 +21,13 @@ func setupApi(r *gin.RouterGroup, db *sqlx.DB, sender sender.Sender, mediaServer
 	r.POST("/posts", func(c *gin.Context) {
 		userData := auth.GetAPIUserData(c)
 
-		ginhelpers.API(c, web.ApiNewPost(c, db, sender, userData.DBUser, mediaReplacer))
+		ginhelpers.API(c, web.ApiNewPost(c, db, sender, userData.DBUser, links.MediaReplacer))
 	})
 
 	r.POST("/posts/:id", func(c *gin.Context) {
 		userData := auth.GetAPIUserData(c)
 
-		ginhelpers.API(c, web.ApiEditPost(c, db, sender, userData.DBUser, mediaReplacer, c.Param("id")))
+		ginhelpers.API(c, web.ApiEditPost(c, db, sender, userData.DBUser, links.MediaReplacer, c.Param("id")))
 	})
 
 	r.DELETE("/posts/:id", func(c *gin.Context) {

--- a/cmd/web/client/html/header.html
+++ b/cmd/web/client/html/header.html
@@ -11,6 +11,9 @@
     <meta property="og:site_name" content="Private communities">
     <meta property="og:type" content="website">
     <link rel="stylesheet" href="{{ static_asset "main.css" }}" />
+    {{ if .RSSFeed }}
+    <link rel="alternate" type="application/rss+xml" title="RSS" href="{{ .RSSFeed }}" />
+    {{ end }}
     <link rel="apple-touch-icon" sizes="180x180" href="{{ static_asset "static/apple-touch-icon.png" }}">
     <link rel="icon" type="image/png" sizes="32x32" href="{{ static_asset "static/favicon-32x32.png" }}">
     <link rel="icon" type="image/png" sizes="16x16" href="{{ static_asset "static/favicon-16x16.png" }}">

--- a/cmd/web/main.go
+++ b/cmd/web/main.go
@@ -41,7 +41,6 @@ import (
 	"github.com/can3p/pcom/pkg/web"
 	"github.com/gin-contrib/sessions"
 	"github.com/gin-gonic/gin"
-	"github.com/google/uuid"
 	"github.com/jmoiron/sqlx"
 	_ "github.com/joho/godotenv/autoload"
 	_ "github.com/lib/pq" // postgres db driver
@@ -705,28 +704,10 @@ func main() {
 	}
 }
 
-// the whole idea there is to keep only an identifier in the markdown
-// source text and give us flexibility to serve the image from
-// any source like cdn without touching saved text
-func mediaReplacer(inURL string) (bool, string) {
-	parts := strings.Split(inURL, ".")
-
-	if len(parts) != 2 {
-		return false, ""
-	}
-
-	if _, err := uuid.Parse(parts[0]); err != nil {
-		return false, ""
-	}
-
-	// all the checks are postponed till the actual call
-	return true, links.AbsLink("uploaded_media", inURL)
-}
-
 func funcmap(staticAsset staticAssetFunc) template.FuncMap {
 	markdown := func(view types.HTMLView) func(s string, add ...string) template.HTML {
 		return func(s string, add ...string) template.HTML {
-			return markdown.ToEnrichedTemplate(s, view, mediaReplacer, func(in string, add2 ...string) string {
+			return markdown.ToEnrichedTemplate(s, view, links.MediaReplacer, func(in string, add2 ...string) string {
 				// ugly hack to handle cut links
 				if in == "single_post_special" {
 					args := []string{}

--- a/cmd/web/main.go
+++ b/cmd/web/main.go
@@ -408,7 +408,7 @@ func main() {
 
 		dbPost := post.MustGet().Post.Post
 
-		dbPost.Body = markdown.ReplaceImageUrls(dbPost.Body, mediaReplacer)
+		dbPost.Body = markdown.ReplaceImageUrls(dbPost.Body, links.MediaReplacer)
 
 		serialized := postops.SerializePost(dbPost)
 		c.String(http.StatusOK, string(serialized))
@@ -619,13 +619,13 @@ func main() {
 		var err error
 
 		if postID == "" {
-			form, err = forms.NewPostFormNew(c, db, sender, dbUser, mediaReplacer, c.PostForm("prompt_id"))
+			form, err = forms.NewPostFormNew(c, db, sender, dbUser, links.MediaReplacer, c.PostForm("prompt_id"))
 
 			if err != nil {
 				panic(err)
 			}
 		} else {
-			form, err = forms.EditPostFormNew(c, db, sender, dbUser, mediaReplacer, postID)
+			form, err = forms.EditPostFormNew(c, db, sender, dbUser, links.MediaReplacer, postID)
 
 			if err != nil {
 				if err == ginhelpers.ErrNotFound {
@@ -644,7 +644,7 @@ func main() {
 		userData := auth.GetUserData(c)
 		dbUser := userData.DBUser
 
-		form := forms.NewCommentFormNew(sender, dbUser, c.PostForm("post_id"), mediaReplacer)
+		form := forms.NewCommentFormNew(sender, dbUser, c.PostForm("post_id"), links.MediaReplacer)
 
 		gogoForms.DefaultHandler(c, db, form)
 	})

--- a/go.mod
+++ b/go.mod
@@ -39,6 +39,7 @@ require (
 	github.com/goccy/go-json v0.10.2 // indirect
 	github.com/gofrs/uuid v4.2.0+incompatible // indirect
 	github.com/gorilla/context v1.1.1 // indirect
+	github.com/gorilla/feeds v1.2.0 // indirect
 	github.com/gorilla/securecookie v1.1.1 // indirect
 	github.com/gorilla/sessions v1.2.1 // indirect
 	github.com/hexops/gotextdiff v1.0.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -297,6 +297,8 @@ github.com/googleapis/gax-go/v2 v2.4.0/go.mod h1:XOTVJ59hdnfJLIP/dh8n5CGryZR2LxK
 github.com/googleapis/google-cloud-go-testing v0.0.0-20200911160855-bcd43fbb19e8/go.mod h1:dvDLG8qkwmyD9a/MJJN3XJcT3xFxOKAvTZGvuZmac9g=
 github.com/gorilla/context v1.1.1 h1:AWwleXJkX/nhcU9bZSnZoi3h/qGYqQAGhq6zZe/aQW8=
 github.com/gorilla/context v1.1.1/go.mod h1:kBGZzfjB9CEq2AlWe17Uuf7NDRt0dE0s8S51q0aT7Yg=
+github.com/gorilla/feeds v1.2.0 h1:O6pBiXJ5JHhPvqy53NsjKOThq+dNFm8+DFrxBEdzSCc=
+github.com/gorilla/feeds v1.2.0/go.mod h1:WMib8uJP3BbY+X8Szd1rA5Pzhdfh+HCCAYT2z7Fza6Y=
 github.com/gorilla/securecookie v1.1.1 h1:miw7JPhV+b/lAHSXz4qd/nN9jRiAFV5FwjeKyCS8BvQ=
 github.com/gorilla/securecookie v1.1.1/go.mod h1:ra0sb63/xPlUeL+yeDciTfxMRAA+MP+HVt/4epWDjd4=
 github.com/gorilla/sessions v1.2.1 h1:DHd3rPN5lE3Ts3D8rKkQ8x/0kqfeNmBAaiSi+o7FsgI=

--- a/pkg/links/link.go
+++ b/pkg/links/link.go
@@ -86,6 +86,10 @@ func Link(name string, args ...string) string {
 		out = "/controls/action/" + builder.Shift()
 	case "uploaded_media":
 		out = "/user-media/" + builder.Shift()
+	case "public_blog_feed":
+		out = "/rss/public/" + builder.Shift()
+	case "private_user_feed":
+		out = "/rss/private/" + builder.Shift()
 	case "login":
 		out = "/login"
 	case "signup":

--- a/pkg/links/replacer.go
+++ b/pkg/links/replacer.go
@@ -1,0 +1,25 @@
+package links
+
+import (
+	"strings"
+
+	"github.com/google/uuid"
+)
+
+// the whole idea there is to keep only an identifier in the markdown
+// source text and give us flexibility to serve the image from
+// any source like cdn without touching saved text
+func MediaReplacer(inURL string) (bool, string) {
+	parts := strings.Split(inURL, ".")
+
+	if len(parts) != 2 {
+		return false, ""
+	}
+
+	if _, err := uuid.Parse(parts[0]); err != nil {
+		return false, ""
+	}
+
+	// all the checks are postponed till the actual call
+	return true, AbsLink("uploaded_media", inURL)
+}

--- a/pkg/markdown/html.go
+++ b/pkg/markdown/html.go
@@ -50,7 +50,7 @@ func NewParser(view types.HTMLView, mediaReplacer types.Replacer[string], link t
 			}), 500),
 	}
 
-	if view == types.ViewEditPreview || view == types.ViewFeed || view == types.ViewSinglePost || view == types.ViewEmail {
+	if view == types.ViewEditPreview || view == types.ViewFeed || view == types.ViewSinglePost || view == types.ViewEmail || view == types.ViewRSS {
 		extensions = append(extensions, blocktags.NewBlockTagExtender(view, link))
 	}
 

--- a/pkg/markdown/mdext/blocktags/renderer.go
+++ b/pkg/markdown/mdext/blocktags/renderer.go
@@ -44,7 +44,7 @@ func (r *BlockTagRenderer) renderBlockTag(w util.BufWriter, source []byte, node 
 		}
 	}
 
-	if r.view == types.ViewEmail {
+	if r.view == types.ViewEmail || r.view == types.ViewRSS {
 		if n.BlockTagName == "cut" {
 			if entering {
 				_, _ = w.WriteString(`<p><a href="` + r.link("single_post_special") + `">Check the rest of the post`)

--- a/pkg/markdown/mdext/videoembed/renderer.go
+++ b/pkg/markdown/mdext/videoembed/renderer.go
@@ -35,7 +35,7 @@ func (r *VideoEmbedRenderer) renderVideoEmbed(w util.BufWriter, source []byte, n
 		return ast.WalkContinue, nil
 	}
 
-	if r.view == types.ViewEmail {
+	if r.view == types.ViewEmail || r.view == types.ViewRSS {
 		_, _ = w.WriteString(`<p><a href="` + n.media.URL() + `">` + n.media.URL() + "</a></p>\n")
 	} else {
 		_, _ = w.WriteString("<p>")

--- a/pkg/postops/rss/rss.go
+++ b/pkg/postops/rss/rss.go
@@ -4,15 +4,15 @@ import (
 	"github.com/can3p/pcom/pkg/links"
 	"github.com/can3p/pcom/pkg/markdown"
 	"github.com/can3p/pcom/pkg/model/core"
+	"github.com/can3p/pcom/pkg/postops"
 	"github.com/can3p/pcom/pkg/types"
 	"github.com/gorilla/feeds"
 )
 
-func ToFeed(title string, link string, author *core.User, posts []*core.Post) *feeds.Feed {
+func ToFeed(title string, link string, author *core.User, posts []*postops.Post) *feeds.Feed {
 	feed := &feeds.Feed{
-		Title:  title,
-		Link:   &feeds.Link{Href: link},
-		Author: &feeds.Author{Name: author.Username, Email: "undisclosed"},
+		Title: title,
+		Link:  &feeds.Link{Href: link},
 	}
 
 	items := []*feeds.Item{}
@@ -28,8 +28,8 @@ func ToFeed(title string, link string, author *core.User, posts []*core.Post) *f
 				Name: func() string {
 					var by string
 
-					if post.R.User != nil {
-						by = "@" + post.R.User.Username
+					if post.Author != nil {
+						by = "@" + post.Author.Username
 					} else {
 						by = "Anonymous User"
 					}

--- a/pkg/postops/rss/rss.go
+++ b/pkg/postops/rss/rss.go
@@ -1,0 +1,49 @@
+package rss
+
+import (
+	"github.com/can3p/pcom/pkg/links"
+	"github.com/can3p/pcom/pkg/markdown"
+	"github.com/can3p/pcom/pkg/model/core"
+	"github.com/can3p/pcom/pkg/types"
+	"github.com/gorilla/feeds"
+)
+
+func ToFeed(title string, link string, author *core.User, posts []*core.Post) *feeds.Feed {
+	feed := &feeds.Feed{
+		Title:  title,
+		Link:   &feeds.Link{Href: link},
+		Author: &feeds.Author{Name: author.Username, Email: "undisclosed"},
+	}
+
+	items := []*feeds.Item{}
+
+	for _, post := range posts {
+		content := markdown.ToEnrichedTemplate(post.Body, types.ViewRSS, links.MediaReplacer, func(in string, add2 ...string) string {
+			return links.AbsLink(in, add2...)
+		})
+
+		items = append(items, &feeds.Item{
+			Title: post.Subject,
+			Author: &feeds.Author{
+				Name: func() string {
+					var by string
+
+					if post.R.User != nil {
+						by = "@" + post.R.User.Username
+					} else {
+						by = "Anonymous User"
+					}
+
+					return by
+				}(),
+			},
+			Link:        &feeds.Link{Href: links.AbsLink("post", post.ID)},
+			Description: string(content),
+			Created:     post.CreatedAt.Time,
+		})
+	}
+
+	feed.Items = items
+
+	return feed
+}

--- a/pkg/postops/rss/rss.go
+++ b/pkg/postops/rss/rss.go
@@ -18,9 +18,13 @@ func ToFeed(title string, link string, author *core.User, posts []*postops.Post)
 	items := []*feeds.Item{}
 
 	for _, post := range posts {
-		content := markdown.ToEnrichedTemplate(post.Body, types.ViewRSS, links.MediaReplacer, func(in string, add2 ...string) string {
-			return links.AbsLink(in, add2...)
-		})
+		content := "Post is not public, follow the link to read the text"
+
+		if post.VisibilityRadius == core.PostVisibilityPublic {
+			content = string(markdown.ToEnrichedTemplate(post.Body, types.ViewRSS, links.MediaReplacer, func(in string, add2 ...string) string {
+				return links.AbsLink(in, add2...)
+			}))
+		}
 
 		items = append(items, &feeds.Item{
 			Title: post.Subject,
@@ -38,7 +42,7 @@ func ToFeed(title string, link string, author *core.User, posts []*postops.Post)
 				}(),
 			},
 			Link:        &feeds.Link{Href: links.AbsLink("post", post.ID)},
-			Description: string(content),
+			Description: content,
 			Created:     post.CreatedAt.Time,
 		})
 	}

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -13,4 +13,5 @@ const (
 	ViewComment     HTMLView = "comment"
 	ViewArticle     HTMLView = "article"
 	ViewEmail       HTMLView = "post_notification_email"
+	ViewRSS         HTMLView = "rss_feed"
 )

--- a/pkg/web/func.go
+++ b/pkg/web/func.go
@@ -29,6 +29,7 @@ type BasePage struct {
 	User        *auth.UserData
 	StyleNonce  *string
 	ScriptNonce *string
+	RSSFeed     string
 }
 
 func getBasePage(c *gin.Context, name string, userData *auth.UserData) *BasePage {


### PR DESCRIPTION
Current approach:
- blog feed should contain only public posts
- private user feed should contain all the posts from the feed, however we need to strip out the body of private posts to make sure we leak as little information as possible