### PR TITLE
Introduce explore feed

### DIFF
--- a/cmd/scripts/toggle_open_registration/main.go
+++ b/cmd/scripts/toggle_open_registration/main.go
@@ -36,7 +36,7 @@ func main() { //nolint:typecheck
 		}
 
 		settings.RegistrationOpen = *enable
-		_, err = settings.Update(ctx, tx, boil.Infer())
+		_, err = settings.Update(ctx, tx, boil.Whitelist(core.SystemSettingColumns.RegistrationOpen))
 
 		return err
 	})

--- a/cmd/web/client/html/feed.html
+++ b/cmd/web/client/html/feed.html
@@ -1,40 +1,15 @@
 {{ template "header.html" . }}
+{{ if .User.IsLoggedIn }}
 <link rel="stylesheet" href="{{ link "user_styles" .User.DBUser.Username }}" />
+{{ end }}
 
 <div class="user-styles-applied us-user-home user-home">
 <div class="container col-md-8">
   <div class="row justify-content-md-center mt-lg-4 mt-2">
-    <h1 class="us-user-header user-header"><a href="{{ link "user" .User.DBUser.Username }}">{{ .User.DBUser.Username }}</a>  &#8594; Your Feed</h1>
+    <h1 class="us-user-header user-header">{{ if .User.IsLoggedIn }}<a href="{{ link "user" .User.DBUser.Username }}">{{ .User.DBUser.Username }}</a>  &#8594; {{ end }}{{ .Name }}</h1>
 
-    {{ template "form--post-prompt.html" toMap "DirectConnections" .DirectConnections }}
-
-    {{ range .OpenPrompts }}
-      <div class="mt-3">
-        <div class="card">
-          <h5 class="card-header fs-6">
-            <a href="{{ link "user" .Author.Username }}">{{ .Author.Username }}</a> prompted you to write a post at {{ renderTimestamp .Prompt.CreatedAt $.User.DBUser }}
-          </h5>
-          <div class="card-body">
-            <div class="d-flex">
-              <div class="p-2 flex-grow-1">{{ .Prompt.Message }}</div>
-              {{ if .Post }}
-              <div class="p-2"><a href="{{ link "edit_post" .Post.ID }}">Edit your post</a></div>
-              {{ else }}
-              <div class="p-2"><a href="{{ link "write" "prompt" .Prompt.ID }}">Write</a></div>
-              {{ end }}
-              <div class="p-2">
-                <button type="button"
-                        class="btn btn-sm btn-danger"
-                        data-controller="action"
-                        data-action="action#run"
-                        data-action-action-value="dismiss_prompt"
-                        data-prompt-id="{{ .Prompt.ID }}"
-                        data-action-prompt-value="Do you want to dismiss the prompt from  {{ .Author.Username }}?"
-                        >Dismiss</button>
-            </div>
-          </div>
-        </div>
-      </div>
+    {{ if .Capabilities.ShowPromptForm }}
+      {{ template "partial--feed-prompts.html" toMap "OpenPrompts" .OpenPrompts "DirectConnections" .DirectConnections }}
     {{ end }}
 
     {{ if eq (len .Items) 0 }}

--- a/cmd/web/client/html/header--links.html
+++ b/cmd/web/client/html/header--links.html
@@ -2,6 +2,7 @@
 <span class="navbar-text p-2">Hi <a href="{{ link "user" .User.DBUser.Username }}">{{ .User.DBUser.Username }}</a>!</span>
 <ul class="navbar-nav gap-3">
   <li class="nav-item p-2"><a class="{{ .LinkClass }}" href="{{ link "default_authorized_home" }}">Feed</a></li>
+  <li class="nav-item p-2"><a class="{{ .LinkClass }}" href="{{ link "explore" }}">Explore</a></li>
   <li class="nav-item p-2"><a class="{{ .LinkClass }}" href="{{ link "write" }}">Write</a></li>
   <li class="nav-item p-2"><a class="{{ .LinkClass }}" href="{{ link "controls" }}">Controls</a></li>
   <li class="nav-item p-2"><a class="{{ .LinkClass }}" href="{{ link "settings" }}">Settings</a></li>
@@ -9,6 +10,7 @@
 {{ else }}
 <ul class="navbar-nav gap-3">
   <li class="nav-item p-2"><a class="{{ .LinkClass }}" href="/">Home</a></li>
+  <li class="nav-item p-2"><a class="{{ .LinkClass }}" href="{{ link "explore" }}">Explore</a></li>
   <li class="nav-item p-2"><a class="{{ .LinkClass }}" href="{{ link "article" "why" }}">Why {{ .ProjectName }}?</a></li>
   <li class="nav-item p-2"><a class="{{ .LinkClass }}" href="{{ link "login" }}">Login</a></li>
 </ul>

--- a/cmd/web/client/html/partial--feed-prompts.html
+++ b/cmd/web/client/html/partial--feed-prompts.html
@@ -1,0 +1,31 @@
+{{ template "form--post-prompt.html" toMap "DirectConnections" .DirectConnections }}
+
+{{ range .OpenPrompts }}
+  <div class="mt-3">
+    <div class="card">
+      <h5 class="card-header fs-6">
+        <a href="{{ link "user" .Author.Username }}">{{ .Author.Username }}</a> prompted you to write a post at {{ renderTimestamp .Prompt.CreatedAt $.User.DBUser }}
+      </h5>
+      <div class="card-body">
+        <div class="d-flex">
+          <div class="p-2 flex-grow-1">{{ .Prompt.Message }}</div>
+          {{ if .Post }}
+          <div class="p-2"><a href="{{ link "edit_post" .Post.ID }}">Edit your post</a></div>
+          {{ else }}
+          <div class="p-2"><a href="{{ link "write" "prompt" .Prompt.ID }}">Write</a></div>
+          {{ end }}
+          <div class="p-2">
+            <button type="button"
+                    class="btn btn-sm btn-danger"
+                    data-controller="action"
+                    data-action="action#run"
+                    data-action-action-value="dismiss_prompt"
+                    data-prompt-id="{{ .Prompt.ID }}"
+                    data-action-prompt-value="Do you want to dismiss the prompt from  {{ .Author.Username }}?"
+                    >Dismiss</button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+{{ end }}

--- a/cmd/web/main.go
+++ b/cmd/web/main.go
@@ -549,6 +549,12 @@ func main() {
 		ginhelpers.HTML(c, "feed.html", web.Feed(c, db, &userData, false))
 	})
 
+	r.GET("/explore", func(c *gin.Context) {
+		userData := auth.GetUserData(c)
+
+		ginhelpers.HTML(c, "feed.html", web.Explore(c, db, &userData))
+	})
+
 	r.GET("/rss/private/:key", func(c *gin.Context) {
 		api, err := core.UserAPIKeys(
 			core.UserAPIKeyWhere.APIKey.EQ(c.Param("key")),

--- a/pkg/links/link.go
+++ b/pkg/links/link.go
@@ -28,6 +28,8 @@ func Link(name string, args ...string) string {
 		out = "/write"
 	case "feed":
 		out = "/feed"
+	case "explore":
+		out = "/explore"
 	case "privacy_policy":
 		out = "/articles/privacy_policy"
 	case "terms_of_service":


### PR DESCRIPTION
Having a social network without any way to explore it is no fun, and now that we have public posts, we can have another go with explore feed.

This time we'll show only public posts by users who have set profile visibility as public or for all registered users (in case the visitor is logged in)
